### PR TITLE
FIX - added missing fmod procedure

### DIFF
--- a/src/chipmunk.nim
+++ b/src/chipmunk.nim
@@ -425,6 +425,11 @@ proc fabs*(f: Float): Float {.inline, cdecl.} =
   ## Return the absolute value of a cpFloat.
   return if (f < 0): - f else: f
 
+proc fmod*(x, y: float): float {.inline, cdecl.} =
+  ## Calculate the modulus (remainder) of x divided by y.
+  let quotient = floor(x / y)
+  result = x - quotient * y
+
 
 proc fclamp*(f: Float; min: Float; max: Float): Float {.inline, cdecl.} =
   ## Clamp `f` to be between `min` and `max`.


### PR DESCRIPTION
Added the fmod procedure to the Chipmunk library. fmod calculates the modulus (remainder) of a floating-point value after division. This function is used in the wrapVect procedure but was missing:

```
proc wrapVect(bb: BB; v: Vect): Vect {.inline, cdecl.} =
  ## Wrap a vector to a bounding box.
  var dx = fabs(bb.r - bb.l)
  var modx = fmod(v.x - bb.l, dx) # missing fmod procedure
  var x = if modx > 0.0: modx else: modx + dx
  var dy = fabs(bb.t - bb.b)
  var mody = fmod(v.y - bb.b, dy) # missing fmod procedure
  var y = if mody > 0.0: mody else: mody + dy
  result = v(x + bb.l, y + bb.b)
```
